### PR TITLE
Versioned dependencies

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ordo-one/package-latency-tools",
       "state" : {
-        "branch" : "main",
-        "revision" : "bc451c5a3246c26e0d2feb0987427408349a8fe6"
+        "revision" : "bc451c5a3246c26e0d2feb0987427408349a8fe6",
+        "version" : "0.0.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-        .package(url: "https://github.com/ordo-one/package-latency-tools", branch: "main"),
+        .package(url: "https://github.com/ordo-one/package-latency-tools", .upToNextMajor(from: "0.0.1")),
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Description

Unable to use 0.0.5 in downstream projects as have issue:
```
error: Dependencies could not be resolved because root depends on 'package-concurrency-helpers' 0.0.5..<1.0.0.
'package-concurrency-helpers' >= 0.0.5 cannot be used because no versions of 'package-concurrency-helpers' match the requirement 0.0.6..<1.0.0 and package 'package-concurrency-helpers' is required using a stable-version but 'package-concurrency-helpers' depends on an unstable-version package 'package-latency-tools'.
```
