### PR TITLE
feat: [sc-1334] Protected<T> property wrapper

### DIFF
--- a/Sources/ConcurrencyHelpers/NIOSendable.swift
+++ b/Sources/ConcurrencyHelpers/NIOSendable.swift
@@ -15,18 +15,18 @@
 // Adopted from SwiftNIO for boxing values between concurrency domains when needed
 
 /*
-#if swift(>=5.5) && canImport(_Concurrency)
-public typealias NIOSendable = Swift.Sendable
-#else
-public typealias NIOSendable = Any
-#endif
+ #if swift(>=5.5) && canImport(_Concurrency)
+ public typealias NIOSendable = Swift.Sendable
+ #else
+ public typealias NIOSendable = Any
+ #endif
 
-#if swift(>=5.6)
-@preconcurrency public protocol NIOPreconcurrencySendable: Sendable {}
-#else
-public protocol NIOPreconcurrencySendable {}
-#endif
-*/
+ #if swift(>=5.6)
+ @preconcurrency public protocol NIOPreconcurrencySendable: Sendable {}
+ #else
+ public protocol NIOPreconcurrencySendable {}
+ #endif
+ */
 
 /// ``UnsafeTransfer`` can be used to make non-`Sendable` values `Sendable`.
 /// As the name implies, the usage of this is unsafe because it disables the sendable checking of the compiler.
@@ -42,7 +42,7 @@ public struct UnsafeTransfer<Wrapped> {
 }
 
 #if swift(>=5.5) && canImport(_Concurrency)
-extension UnsafeTransfer: @unchecked Sendable {}
+    extension UnsafeTransfer: @unchecked Sendable {}
 #endif
 
 extension UnsafeTransfer: Equatable where Wrapped: Equatable {}
@@ -59,6 +59,7 @@ public final class UnsafeMutableTransferBox<Wrapped> {
         self.wrappedValue = wrappedValue
     }
 }
+
 #if swift(>=5.5) && canImport(_Concurrency)
-extension UnsafeMutableTransferBox: @unchecked Sendable {}
+    extension UnsafeMutableTransferBox: @unchecked Sendable {}
 #endif

--- a/Sources/ConcurrencyHelpers/Protected.swift
+++ b/Sources/ConcurrencyHelpers/Protected.swift
@@ -1,8 +1,8 @@
 /// Thread safe access to simple variable protected by lock
 @propertyWrapper
 public final class Protected<T> {
-    var value: T
-    var lock = ConcurrencyHelpers.Lock()
+    private var value: T
+    private var lock = ConcurrencyHelpers.Lock()
 
     public init(wrappedValue: T) {
         value = wrappedValue

--- a/Sources/ConcurrencyHelpers/Protected.swift
+++ b/Sources/ConcurrencyHelpers/Protected.swift
@@ -1,0 +1,36 @@
+/// Thread safe access to simple variable protected by lock
+@propertyWrapper
+public final class Protected<T> {
+    var value: T
+    var lock: ConcurrencyHelpers.Lock
+
+    public init(wrappedValue: T) {
+        value = wrappedValue
+        lock = .init()
+    }
+
+    public var wrappedValue: T {
+        get { lock.withLock { value } }
+        set { lock.withLockVoid { value = newValue } }
+    }
+
+    public var projectedValue: Protected<T> { self }
+
+    /// Provides thread-safe scoped access to protected value
+    /// - Parameter body: The clouse to be called for scoped access
+    /// - Returns: The return value of the closure
+    public func read<V>(_ body: (T) -> V) -> V {
+        lock.withLock {
+            body(value)
+        }
+    }
+
+    /// Provides thread-safe scoped mutable access to protected value
+    /// - Parameter body: The clouse to be called for scoped access
+    /// - Returns: The return value of the closure
+    public func write<V>(_ body: (inout T) -> V) -> V {
+        lock.withLock {
+            body(&value)
+        }
+    }
+}

--- a/Sources/ConcurrencyHelpers/Protected.swift
+++ b/Sources/ConcurrencyHelpers/Protected.swift
@@ -2,11 +2,10 @@
 @propertyWrapper
 public final class Protected<T> {
     var value: T
-    var lock: ConcurrencyHelpers.Lock
+    var lock = ConcurrencyHelpers.Lock()
 
     public init(wrappedValue: T) {
         value = wrappedValue
-        lock = .init()
     }
 
     public var wrappedValue: T {
@@ -17,7 +16,7 @@ public final class Protected<T> {
     public var projectedValue: Protected<T> { self }
 
     /// Provides thread-safe scoped access to protected value
-    /// - Parameter body: The clouse to be called for scoped access
+    /// - Parameter body: The closure to be called for scoped access
     /// - Returns: The return value of the closure
     public func read<V>(_ body: (T) -> V) -> V {
         lock.withLock {
@@ -26,7 +25,7 @@ public final class Protected<T> {
     }
 
     /// Provides thread-safe scoped mutable access to protected value
-    /// - Parameter body: The clouse to be called for scoped access
+    /// - Parameter body: The closure to be called for scoped access
     /// - Returns: The return value of the closure
     public func write<V>(_ body: (inout T) -> V) -> V {
         lock.withLock {

--- a/Sources/Helpers/UnsafeRetained.swift
+++ b/Sources/Helpers/UnsafeRetained.swift
@@ -8,7 +8,6 @@
 
 /// Protocol defines a correct way to release an object
 public protocol Releasable {
-    
     /// The function is called when and only when last reference to the object is dropped
     /// Object have be properly released, owned memory deallocated etc
     func release()

--- a/Tests/ConcurrencyHelpersTests/ConcurrencyHelpersTests.swift
+++ b/Tests/ConcurrencyHelpersTests/ConcurrencyHelpersTests.swift
@@ -28,4 +28,38 @@ final class ConcurrencyHelpersTests: XCTestCase {
 
         lock.withLockVoid { _ = 4 }
     }
+
+    struct Data {
+        @Protected public var valueA: Int = 1
+        @Protected public var valueB: Int? = nil
+
+        public mutating func setA(_ a: Int) {
+            _valueA.write {
+                $0 = a
+            }
+        }
+    }
+
+    func testProceted() {
+        let data = Data()
+
+        XCTAssertEqual(data.valueA, 1)
+        XCTAssertEqual(data.valueB, nil)
+
+        data.valueA = 2
+        data.valueB = 3
+
+        XCTAssertEqual(data.valueA, 2)
+        XCTAssertEqual(data.valueB, 3)
+
+        let valueAis2 = data.$valueA.read { value in
+            value == 2
+        }
+        XCTAssertEqual(valueAis2, true)
+
+        data.$valueB.write {
+            $0 = nil
+        }
+        XCTAssertEqual(data.valueB, nil)
+    }
 }

--- a/Tests/ConcurrencyHelpersTests/ConcurrencyHelpersTests.swift
+++ b/Tests/ConcurrencyHelpersTests/ConcurrencyHelpersTests.swift
@@ -30,8 +30,8 @@ final class ConcurrencyHelpersTests: XCTestCase {
     }
 
     struct Data {
-        @Protected public var valueA: Int = 1
-        @Protected public var valueB: Int? = nil
+        @Protected var valueA: Int = 1
+        @Protected var valueB: Int? = nil
 
         public mutating func setA(_ a: Int) {
             _valueA.write {
@@ -40,7 +40,7 @@ final class ConcurrencyHelpersTests: XCTestCase {
         }
     }
 
-    func testProceted() {
+    func testProtected() {
         let data = Data()
 
         XCTAssertEqual(data.valueA, 1)

--- a/Tests/HelpersTests/UnsafeRetainedTests.swift
+++ b/Tests/HelpersTests/UnsafeRetainedTests.swift
@@ -6,47 +6,46 @@
 //
 // http://www.apache.org/licenses/LICENSE-2.0
 
-@testable import Helpers
 import ConcurrencyHelpers
+@testable import Helpers
 import XCTest
 
 var lock: Lock = .init()
 var checksPassed = 0
 
 final class UnsafeRetainedTests: XCTestCase {
-    
     func testStorage() async {
         // Allocate storage, fill it with some data
         let storage: UnsafeMutablePointer<UInt8> = .allocate(capacity: 256)
-        for i in 0..<256 {
+        for i in 0 ..< 256 {
             storage[i] = UInt8(i)
         }
         let storagePtr = MyUInt8ArrayPtr(storage, 256)
-        
+
         // Make storage UnsafeRetained, release policy is to deallocate when no one need this
         var retainedStorage: UnsafeRetained<MyUInt8ArrayPtr>? = .init(storagePtr, .release)
-        
+
         // Now let's process data simultaneously
         let result = await withTaskGroup(of: Bool.self, returning: Bool.self) { taskGroup in
-            for i in 0..<256 {
+            for i in 0 ..< 256 {
                 // Create UnsafeRetained with release policy 'forsake' and reference to underlying storage
                 let ptr = UnsafeRetained<UnsafePointer<UInt8>>(&storage[i], .forsake, retainedStorage)
-                taskGroup.addTask() {
+                taskGroup.addTask {
                     // This function checks that 'ptr' points to memory with value 'i'
                     // See this function below
-                    return await self.checkValue(value: UInt8(i), ptr: ptr)
+                    await self.checkValue(value: UInt8(i), ptr: ptr)
                 }
             }
-            
+
             // No need to keep explicit reference to storage,
             // but it's not deallocated since it is referenced from data pointers
             retainedStorage = nil
-            
+
             // But, let's check that data is not cleaned
-            for i in 0..<256 {
+            for i in 0 ..< 256 {
                 XCTAssertTrue(storage[i] == UInt8(i))
             }
-            
+
             // Then let's collect the result
             var result = true
             for await childResult in taskGroup {
@@ -60,12 +59,12 @@ final class UnsafeRetainedTests: XCTestCase {
             XCTAssertTrue(checksPassed == 256)
         }
     }
-    
+
     // Function checks that 'ptr' points to memory with value 'value'
     func checkValue(value: UInt8, ptr: UnsafeRetained<UnsafePointer<UInt8>>) async -> Bool {
         do {
             // Sleep to bring some randomness and handle tasks in different order then created
-            try await Task.sleep(nanoseconds: UInt64.random(in: 1_000...5_000))
+            try await Task.sleep(nanoseconds: UInt64.random(in: 1_000 ... 5_000))
             if value == ptr.data[0] {
                 lock.withLockVoid {
                     checksPassed += 1
@@ -77,29 +76,28 @@ final class UnsafeRetainedTests: XCTestCase {
             return false
         }
     }
-    
+
     // Helper struct which is not only deallocate memory, but also set it to all 0's
     struct MyUInt8ArrayPtr: Releasable {
         var ptr: UnsafeMutablePointer<UInt8>
         var size: Int
-        
+
         public init(_ ptr: UnsafeMutablePointer<UInt8>, _ size: Int) {
             self.ptr = ptr
             self.size = size
         }
-        
+
         public func release() {
             // Make sure we release memory only after all tasks are done, so all references are dropped
             lock.withLockVoid {
                 XCTAssertTrue(checksPassed == 256)
             }
             // Clean memory
-            for i in 0..<size {
+            for i in 0 ..< size {
                 ptr[i] = 0
             }
             // Deallocate memory
             ptr.deallocate()
         }
     }
-    
 }


### PR DESCRIPTION
## Description

- Apply swift format
- Add generic Protected<T> property wrapper for thread safe access to variables.

## How Has This Been Tested?

- Small non-concurrent test added.

## Minimal checklist:

- [ ] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
