### PR TITLE
chore: simplify Spinlock implementation

### DIFF
--- a/Sources/ConcurrencyHelpers/Spinlock.swift
+++ b/Sources/ConcurrencyHelpers/Spinlock.swift
@@ -16,17 +16,15 @@ public final class Spinlock {
     private static let locked: State = true
     private static let unlocked: State = false
 
-    private let stateStorage = UnsafeMutablePointer<State.AtomicRepresentation>.allocate(capacity: 1)
     private var state: UnsafeAtomic<State>
 
     /// Create a new spin-lock.
     public init() {
-        stateStorage.initialize(to: State.AtomicRepresentation(Self.unlocked))
-        state = .init(at: stateStorage)
+        state = .create(Self.unlocked)
     }
 
     deinit {
-        stateStorage.deallocate()
+        state.destroy()
     }
 
     /// Acquire the lock.


### PR DESCRIPTION
Make use of UnsafeAtomic.create() static method that allocates atomic state instead of doing the allocation ourselves.
Also don't need to store the pointer to state separately which lowers the size of the Spinlock object.

## Description

Include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
