### PR TITLE
chore: allow throwing callbacks in Protected read()/write() methods

### DIFF
--- a/Sources/ConcurrencyHelpers/Protected.swift
+++ b/Sources/ConcurrencyHelpers/Protected.swift
@@ -18,18 +18,18 @@ public final class Protected<T> {
     /// Provides thread-safe scoped access to protected value
     /// - Parameter body: The closure to be called for scoped access
     /// - Returns: The return value of the closure
-    public func read<V>(_ body: (T) -> V) -> V {
-        lock.withLock {
-            body(value)
+    public func read<V>(_ body: (T) throws -> V) rethrows -> V {
+        try lock.withLock {
+            try body(value)
         }
     }
 
     /// Provides thread-safe scoped mutable access to protected value
     /// - Parameter body: The closure to be called for scoped access
     /// - Returns: The return value of the closure
-    public func write<V>(_ body: (inout T) -> V) -> V {
-        lock.withLock {
-            body(&value)
+    public func write<V>(_ body: (inout T) throws -> V) rethrows -> V {
+        try lock.withLock {
+            try body(&value)
         }
     }
 }

--- a/Tests/ConcurrencyHelpersTests/ConcurrencyHelpersTests.swift
+++ b/Tests/ConcurrencyHelpersTests/ConcurrencyHelpersTests.swift
@@ -63,6 +63,11 @@ final class ConcurrencyHelpersTests: XCTestCase {
             $0 = nil
         }
         XCTAssertEqual(data.valueB, nil)
+
+        struct MyError: Error {}
+
+        XCTAssertThrowsError(try data.$valueA.read { _ in throw MyError() })
+        XCTAssertThrowsError(try data.$valueB.write { _ in throw MyError() })
     }
 
     func testSpinlock() async {


### PR DESCRIPTION
## Description

Include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [x] I have added unit and/or integration tests that prove my fix is effective or that my feature works
