### PR TITLE
feat: add generic Box helper

### DIFF
--- a/Sources/Helpers/Box.swift
+++ b/Sources/Helpers/Box.swift
@@ -1,0 +1,34 @@
+// Generic box to allow sharing of values.
+// See https://www.hackingwithswift.com/articles/92/how-to-share-structs-using-boxing
+
+public final class Box<T> {
+    public var value: T
+
+    public init(_ value: T) {
+        self.value = value
+    }
+}
+
+extension Box: Equatable where T: Equatable {
+    public static func == (lhs: Box, rhs: Box) -> Bool {
+        return lhs.value == rhs.value
+    }
+}
+
+extension Box: Comparable where T: Comparable {
+    public static func < (lhs: Box, rhs: Box) -> Bool {
+        return lhs.value < rhs.value
+    }
+}
+
+extension Box: CustomStringConvertible where T: CustomStringConvertible {
+    public var description: String {
+        "\(value.description)"
+    }
+}
+
+extension Box: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        "Box(\(String(reflecting: value)))"
+    }
+}

--- a/Sources/Helpers/Box.swift
+++ b/Sources/Helpers/Box.swift
@@ -1,6 +1,8 @@
-// Generic box to allow sharing of values.
-// See https://www.hackingwithswift.com/articles/92/how-to-share-structs-using-boxing
-
+/**
+ * Generic box to allow sharing of objects of value-types (structs, enums, etc)
+ *
+ * See https://www.hackingwithswift.com/articles/92/how-to-share-structs-using-boxing
+ */
 public final class Box<T> {
     public var value: T
 

--- a/Tests/HelpersTests/BoxTests.swift
+++ b/Tests/HelpersTests/BoxTests.swift
@@ -1,6 +1,7 @@
 import Helpers
 import XCTest
 
+// swiftlint:disable identifier_name
 final class BoxTests: XCTestCase {
     func testBox() {
         let a = Box<Int>(10)
@@ -32,6 +33,7 @@ final class BoxTests: XCTestCase {
         let b = Box<Int>(13)
 
         XCTAssertTrue(a < b)
+        // swiftlint:disable:next identical_operands
         XCTAssertTrue(a <= a)
         XCTAssertTrue(a <= b)
         XCTAssertFalse(a > b)
@@ -48,3 +50,4 @@ final class BoxTests: XCTestCase {
         XCTAssertEqual(String(reflecting: a), "Box(10)")
     }
 }
+// swiftlint:enable identifier_name

--- a/Tests/HelpersTests/BoxTests.swift
+++ b/Tests/HelpersTests/BoxTests.swift
@@ -1,0 +1,50 @@
+import Helpers
+import XCTest
+
+final class BoxTests: XCTestCase {
+    func testBox() {
+        let a = Box<Int>(10)
+        XCTAssertEqual(a.value, 10)
+
+        let b = a
+        XCTAssertEqual(b.value, 10)
+
+        a.value = 13
+        XCTAssertEqual(b.value, 13)
+    }
+
+    func testEquatable() {
+        let a = Box<Int>(10)
+        let b = a
+
+        XCTAssertEqual(a, b)
+
+        let c = Box<Int>(10)
+        XCTAssertEqual(a, c)
+        XCTAssertEqual(b, c)
+
+        a.value = 5
+        XCTAssertNotEqual(a, c)
+    }
+
+    func testComparable() {
+        let a = Box<Int>(10)
+        let b = Box<Int>(13)
+
+        XCTAssertTrue(a < b)
+        XCTAssertTrue(a <= a)
+        XCTAssertTrue(a <= b)
+        XCTAssertFalse(a > b)
+        XCTAssertFalse(a >= b)
+    }
+
+    func testStringConvertible() {
+        let a = Box<Int>(10)
+        XCTAssertEqual("\(a)", "10")
+    }
+
+    func testDebugStringConvertible() {
+        let a = Box<Int>(10)
+        XCTAssertEqual(String(reflecting: a), "Box(10)")
+    }
+}


### PR DESCRIPTION
## Description

Add generic Box helper class that allows sharing values.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [x] I have added unit and/or integration tests that prove my fix is effective or that my feature works
