### PR TITLE
feat: add Event synchronisation object

### DIFF
--- a/Sources/ConcurrencyHelpers/Event.swift
+++ b/Sources/ConcurrencyHelpers/Event.swift
@@ -1,0 +1,93 @@
+import Atomics
+
+/**
+ * Synchronization primitive modelled after Event from WinAPI.
+ */
+public final class Event {
+    // Protects continuations array and write to signaled flag.
+    private var lock = Lock()
+
+    // Can be accessed for read without taking lock
+    private var signaled: UnsafeAtomic<Bool>
+
+    private typealias Continuation = CheckedContinuation<Void, Never>
+
+    private var continuations = [Continuation]()
+
+    /**
+     * Initialize a new event.
+     *
+     * - argument signaled: Initial state of event. Non-signaled by default.
+     */
+    public init(signaled: Bool = false) {
+        self.signaled = .create(signaled)
+    }
+
+    /**
+     * Wait for event to become signaled.
+     */
+    public func wait() async {
+        guard !isSignaled else {
+            return
+        }
+
+        lock.lock()
+
+        guard !isSignaled else {
+            lock.unlock()
+            return
+        }
+
+        await withCheckedContinuation {
+            continuations.append($0)
+            lock.unlock()
+        }
+    }
+
+    /**
+     * Check if event is in signaled state.
+     */
+    public var isSignaled: Bool {
+        signaled.load(ordering: .relaxed)
+    }
+
+    /**
+     * Mark event as signaled.
+     *
+     * - returns: 'true' if event was in non-signaled state, 'false' otherwise.
+     */
+    @discardableResult
+    public func signal() -> Bool {
+        guard !isSignaled else { return false }
+
+        var continuationsToResume = [Continuation]()
+
+        let wasSignaled = lock.withLock {
+            guard !isSignaled else { return false }
+
+            signaled.store(true, ordering: .relaxed)
+            swap(&continuations, &continuationsToResume)
+            return true
+        }
+
+        continuationsToResume.forEach { $0.resume() }
+
+        return wasSignaled
+    }
+
+    /**
+     * Reset the event back to non-signaled state.
+     *
+     * - returns: 'true' if event was signaled, 'false' otherwise.
+     */
+    @discardableResult
+    public func reset() -> Bool {
+        guard isSignaled else { return false }
+
+        return lock.withLock {
+            guard isSignaled else { return false }
+            signaled.store(false, ordering: .relaxed)
+            return true
+        }
+    }
+}

--- a/Tests/ConcurrencyHelpersTests/ConcurrencyHelpersTests.swift
+++ b/Tests/ConcurrencyHelpersTests/ConcurrencyHelpersTests.swift
@@ -6,7 +6,8 @@
 //
 // http://www.apache.org/licenses/LICENSE-2.0
 
-@testable import ConcurrencyHelpers
+import Atomics
+import ConcurrencyHelpers
 import XCTest
 
 private final class Counter<Mutex: Lockable>: @unchecked Sendable {
@@ -93,5 +94,29 @@ final class ConcurrencyHelpersTests: XCTestCase {
         }
 
         XCTAssertEqual(counter.value, taskCount * iterationCount)
+    }
+
+    func testEvent() async {
+        await withTaskGroup(of: Int.self) { group in
+            let value = ManagedAtomic<Int>(0)
+
+            let ready = Event()
+
+            for _ in 1 ... 20 {
+                group.addTask {
+                    await ready.wait()
+                    return value.load(ordering: .relaxed)
+                }
+            }
+
+            try? await Task.sleep(nanoseconds: 10_000_000) // let all tasks to run
+
+            value.store(10, ordering: .relaxed)
+            ready.signal()
+
+            let sum = await group.reduce(0, +)
+
+            XCTAssertEqual(sum, 10 * 20)
+        }
     }
 }


### PR DESCRIPTION
## Description

Add Event synchronisation object that allows multiple tasks to wait for some event to occur.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [x] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [x] I have added unit and/or integration tests that prove my fix is effective or that my feature works
