### PR TITLE
feat(minor): add runSync() helper function

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -10,6 +10,15 @@
       }
     },
     {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics",
+      "state" : {
+        "revision" : "6c89474e62719ddcc1e9614989fff2f68208fe10",
+        "version" : "1.1.0"
+      }
+    },
+    {
       "identity" : "swift-docc-plugin",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin",

--- a/Package.swift
+++ b/Package.swift
@@ -31,6 +31,7 @@ let package = Package(
             name: "ConcurrencyHelpers",
             dependencies: [
                 "_PauseShims",
+                "Helpers",
                 .product(name: "Atomics", package: "swift-atomics"),
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,6 @@ let package = Package(
             name: "ConcurrencyHelpers",
             dependencies: [
                 "_PauseShims",
-                "Helpers",
                 .product(name: "Atomics", package: "swift-atomics"),
             ]
         ),

--- a/Sources/ConcurrencyHelpers/RunSync.swift
+++ b/Sources/ConcurrencyHelpers/RunSync.swift
@@ -2,6 +2,11 @@ import Dispatch
 
 /**
  * Runs async closure and waits for its result in non-async code.
+ *
+ * Use with care as this blocks the current thread and violates
+ * "forward progress" Swift concurrency runtime contract.
+ *
+ * See https://developer.apple.com/videos/play/wwdc2021/10254/?time=1582
  */
 public func runSync<T>(_ closure: @escaping () async -> T) -> T {
     let result = UnsafeMutableTransferBox<T?>(nil)
@@ -21,6 +26,11 @@ public func runSync<T>(_ closure: @escaping () async -> T) -> T {
 /**
  * Runs throwing async closure and waits for its result (incl. rethrowing exception)
  * in non-async code.
+ *
+ * Use with care as this blocks the current thread and violates
+ * "forward progress" Swift concurrency runtime contract.
+ *
+ * See https://developer.apple.com/videos/play/wwdc2021/10254/?time=1582
  */
 public func runSync<T>(_ closure: @escaping () async throws -> T) throws -> T{
     func nonthowing() async -> Result<T, Error> {

--- a/Sources/ConcurrencyHelpers/RunSync.swift
+++ b/Sources/ConcurrencyHelpers/RunSync.swift
@@ -5,18 +5,18 @@ import Helpers
  * Runs async closure and waits for its result in non-async code.
  */
 public func runSync<T>(_ closure: @escaping () async -> T) -> T {
-    let result = Box<T?>(nil)
+    let result = UnsafeMutableTransferBox<T?>(nil)
 
     let semaphore = DispatchSemaphore(value: 0)
 
     Task {
-        result.value = await closure()
+        result.wrappedValue = await closure()
         semaphore.signal()
     }
 
     semaphore.wait()
 
-    return result.value!
+    return result.wrappedValue!
 }
 
 /**

--- a/Sources/ConcurrencyHelpers/RunSync.swift
+++ b/Sources/ConcurrencyHelpers/RunSync.swift
@@ -1,5 +1,4 @@
 import Dispatch
-import Helpers
 
 /**
  * Runs async closure and waits for its result in non-async code.

--- a/Sources/ConcurrencyHelpers/RunSync.swift
+++ b/Sources/ConcurrencyHelpers/RunSync.swift
@@ -1,0 +1,36 @@
+import Dispatch
+import Helpers
+
+/**
+ * Runs async closure and waits for its result in non-async code.
+ */
+public func runSync<T>(_ closure: @escaping () async -> T) -> T {
+    let result = Box<T?>(nil)
+
+    let semaphore = DispatchSemaphore(value: 0)
+
+    Task {
+        result.value = await closure()
+        semaphore.signal()
+    }
+
+    semaphore.wait()
+
+    return result.value!
+}
+
+/**
+ * Runs throwing async closure and waits for its result (incl. rethrowing exception)
+ * in non-async code.
+ */
+public func runSync<T>(_ closure: @escaping () async throws -> T) throws -> T{
+    func nonthowing() async -> Result<T, Error> {
+        do {
+            return .success(try await closure())
+        } catch {
+            return .failure(error)
+        }
+    }
+
+    return try runSync(nonthowing).get()
+}

--- a/Tests/ConcurrencyHelpersTests/ConcurrencyHelpersTests.swift
+++ b/Tests/ConcurrencyHelpersTests/ConcurrencyHelpersTests.swift
@@ -94,4 +94,31 @@ final class ConcurrencyHelpersTests: XCTestCase {
 
         XCTAssertEqual(counter.value, taskCount * iterationCount)
     }
+
+    private func someAsyncMethod(argument: Int) async -> Int {
+        try? await Task.sleep(nanoseconds: 10_000)
+        return argument * 2
+    }
+
+    func testRunSync() {
+        let result = runSync { await self.someAsyncMethod(argument: 34) }
+        XCTAssertEqual(result, 34 * 2)
+    }
+
+    struct InvalidArgumentError: Error {}
+
+    private func someThrowingAsyncMethod(argument: Int?) async throws -> Int {
+        try? await Task.sleep(nanoseconds: 10_000)
+        guard let argument else {
+            throw InvalidArgumentError()
+        }
+        return argument * 2
+    }
+
+    func testRunSyncThrowable() {
+        let result = try? runSync { try await self.someThrowingAsyncMethod(argument: 34) }
+        XCTAssertEqual(result, 34 * 2)
+
+        XCTAssertThrowsError(try runSync { try await self.someThrowingAsyncMethod(argument: nil) })
+    }
 }


### PR DESCRIPTION
## Description

Simple helper that allows running async closure in synchronous context.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [x] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [x] I have added unit and/or integration tests that prove my fix is effective or that my feature works
