### PR TITLE
feat(minor): be able to specify priority of the task used in runSync()

### DIFF
--- a/Tests/ConcurrencyHelpersTests/ConcurrencyHelpersTests.swift
+++ b/Tests/ConcurrencyHelpersTests/ConcurrencyHelpersTests.swift
@@ -105,7 +105,12 @@ final class ConcurrencyHelpersTests: XCTestCase {
         XCTAssertEqual(result, 34 * 2)
     }
 
-    struct InvalidArgumentError: Error {}
+    func testRunSyncWithPriority() {
+        let result = runSync(priority: .userInitiated) { await self.someAsyncMethod(argument: 34) }
+        XCTAssertEqual(result, 34 * 2)
+    }
+
+    private struct InvalidArgumentError: Error {}
 
     private func someThrowingAsyncMethod(argument: Int?) async throws -> Int {
         try? await Task.sleep(nanoseconds: 10_000)
@@ -117,6 +122,13 @@ final class ConcurrencyHelpersTests: XCTestCase {
 
     func testRunSyncThrowable() {
         let result = try? runSync { try await self.someThrowingAsyncMethod(argument: 34) }
+        XCTAssertEqual(result, 34 * 2)
+
+        XCTAssertThrowsError(try runSync { try await self.someThrowingAsyncMethod(argument: nil) })
+    }
+
+    func testRunSyncThrowableWithPriority() {
+        let result = try? runSync(priority: .userInitiated) { try await self.someThrowingAsyncMethod(argument: 34) }
         XCTAssertEqual(result, 34 * 2)
 
         XCTAssertThrowsError(try runSync { try await self.someThrowingAsyncMethod(argument: nil) })


### PR DESCRIPTION
## Description

Add `priority` parameter to `runSync()` function that allows specifying priority of the task used to run async code.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [x] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [x] I have added unit and/or integration tests that prove my fix is effective or that my feature works
