### PR TITLE
fix: check for task cancellation in yieldWithBackPressure()

### DIFF
--- a/Sources/ConcurrencyHelpers/YieldWithBackPressure.swift
+++ b/Sources/ConcurrencyHelpers/YieldWithBackPressure.swift
@@ -28,7 +28,7 @@ public func yieldWithBackPressure<Message>(message: Message,
             // Here we can know how many slots remains in the stream
             return true
         case .dropped:
-            // Here we can know what message has beed dropped
+            // Here we can know that a message has been dropped
             if Task.isCancelled {
                 return false
             }

--- a/Sources/ConcurrencyHelpers/YieldWithBackPressure.swift
+++ b/Sources/ConcurrencyHelpers/YieldWithBackPressure.swift
@@ -28,6 +28,9 @@ public func yieldWithBackPressure<Message>(message: Message,
             return true
         case .dropped:
             // Here we can know what message has beed dropped
+            if Task.isCancelled {
+                return false
+            }
             await Task.yield()
             continue
         @unknown default:

--- a/Sources/ConcurrencyHelpers/YieldWithBackPressure.swift
+++ b/Sources/ConcurrencyHelpers/YieldWithBackPressure.swift
@@ -10,6 +10,7 @@
 /// with back pressure logic.
 ///
 /// If `continuation` returns `.dropped`, the method yields the Task and try again.
+/// If the task is cancelled it stops trying and return `false`.
 ///
 /// - Parameter message: The value to yield to the continuation.
 /// - Parameter continuation: The continuation to yield message to.


### PR DESCRIPTION
## Description

Now when the output stream is "full" `yieldWithBackPressure()` will loop infinitely and doesn't react on task cancellation.
Added a check if the current task is cancelled and return `false` in this case.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [x] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [x] I have added unit and/or integration tests that prove my fix is effective or that my feature works
