### PR TITLE
feat(patch): [sc-3285] Add makeStream()

### DIFF
--- a/Sources/ConcurrencyHelpers/MakeStream.swift
+++ b/Sources/ConcurrencyHelpers/MakeStream.swift
@@ -1,0 +1,25 @@
+/// `makeStream` is part of Swift 5.9
+/// https://github.com/apple/swift-evolution/blob/main/proposals/0388-async-stream-factory.md
+public func makeStream<T>(of _: T.Type) -> (AsyncStream<T>, AsyncStream<T>.Continuation) {
+    var resultContinuation: AsyncStream<T>.Continuation?
+    let asyncStream = AsyncStream<T> { continuation in
+        resultContinuation = continuation
+    }
+
+    guard let resultContinuation else {
+        fatalError("makeStream internal error, couldn't extract resultContinuation")
+    }
+    return (asyncStream, resultContinuation)
+}
+
+public func makeSingleStream<T>(of _: T.Type) -> (AsyncStream<T>, AsyncStream<T>.Continuation) {
+    var resultContinuation: AsyncStream<T>.Continuation?
+    let asyncStream = AsyncStream<T>(bufferingPolicy: .bufferingNewest(1)) { continuation in
+        resultContinuation = continuation
+    }
+
+    guard let resultContinuation else {
+        fatalError("makeStream internal error, couldn't extract resultContinuation")
+    }
+    return (asyncStream, resultContinuation)
+}

--- a/Sources/Helpers/MakeStream.swift
+++ b/Sources/Helpers/MakeStream.swift
@@ -6,28 +6,23 @@
 //
 // http://www.apache.org/licenses/LICENSE-2.0
 
-/// `makeStream` is part of Swift 5.9
-/// https://github.com/apple/swift-evolution/blob/main/proposals/0388-async-stream-factory.md
-public func makeStream<T>(of _: T.Type) -> (AsyncStream<T>, AsyncStream<T>.Continuation) {
-    var resultContinuation: AsyncStream<T>.Continuation?
-    let asyncStream = AsyncStream<T> { continuation in
-        resultContinuation = continuation
-    }
+#if swift(<5.9)
+public extension AsyncStream {
+    /// `makeStream` is part of Swift 5.9
+    /// https://github.com/apple/swift-evolution/blob/main/proposals/0388-async-stream-factory.md
+    static func makeStream(
+        of elementType: Element.Type = Element.self,
+        bufferingPolicy limit: Continuation.BufferingPolicy = .unbounded
+    ) -> (stream: AsyncStream<Element>, continuation: AsyncStream<Element>.Continuation) {
+        var resultContinuation: AsyncStream<Element>.Continuation?
+        let stream = AsyncStream<Element>(bufferingPolicy: limit) { continuation in
+            resultContinuation = continuation
+        }
 
-    guard let resultContinuation else {
-        fatalError("makeStream internal error, couldn't extract resultContinuation")
+        guard let resultContinuation else {
+            fatalError("makeStream internal error, couldn't extract resultContinuation")
+        }
+        return (stream: stream, continuation: resultContinuation)
     }
-    return (asyncStream, resultContinuation)
 }
-
-public func makeSingleStream<T>(of _: T.Type) -> (AsyncStream<T>, AsyncStream<T>.Continuation) {
-    var resultContinuation: AsyncStream<T>.Continuation?
-    let asyncStream = AsyncStream<T>(bufferingPolicy: .bufferingNewest(1)) { continuation in
-        resultContinuation = continuation
-    }
-
-    guard let resultContinuation else {
-        fatalError("makeStream internal error, couldn't extract resultContinuation")
-    }
-    return (asyncStream, resultContinuation)
-}
+#endif

--- a/Sources/Helpers/MakeStream.swift
+++ b/Sources/Helpers/MakeStream.swift
@@ -1,3 +1,11 @@
+// Copyright 2023 Ordo One AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+
 /// `makeStream` is part of Swift 5.9
 /// https://github.com/apple/swift-evolution/blob/main/proposals/0388-async-stream-factory.md
 public func makeStream<T>(of _: T.Type) -> (AsyncStream<T>, AsyncStream<T>.Continuation) {


### PR DESCRIPTION
## Description

These two functions are currently in the frontend but probably belong here instead.

Also merged them into one function to match the proposal in https://github.com/apple/swift-evolution/blob/main/proposals/0388-async-stream-factory.md#detailed-design.

Fixes Shortcut story [sc-3285]

Squash merging will be used to merge into `main` (the commit message will be copied from PR text message)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
