### PR TITLE
chore(minor): relax requirements of runSync() arguments

### DIFF
--- a/Sources/ConcurrencyHelpers/UnsafeSendableWrapper.swift
+++ b/Sources/ConcurrencyHelpers/UnsafeSendableWrapper.swift
@@ -1,0 +1,19 @@
+/// A wrapper that forcefully marks a non-Sendable type as Sendable.
+///
+/// - Warning: This should only be used when you are certain that the wrapped type
+///   does not introduce race conditions or shared mutable state.
+///   **Improper use may lead to undefined behavior or data races.**
+///
+/// - Note: This wrapper applies `@unchecked Sendable`, bypassing Swift’s strict concurrency safety.
+///   Use only if the wrapped type is inherently thread-safe.
+public struct UnsafeSendableWrapper<T>: @unchecked Sendable {
+    /// The wrapped instance of the non-Sendable type.
+    public let instance: T
+
+    /// Initializes a new `UnsafeSendableWrapper` with the provided instance.
+    ///
+    /// - Parameter instance: The non-Sendable instance to wrap.
+    public init(instance: T) {
+        self.instance = instance
+    }
+}


### PR DESCRIPTION
Don't need escapability and sendability.

## Description

Include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [ ] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
